### PR TITLE
upgrade to nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Pierre Chifflier <chifflier@wzdftpd.net>"]
 
 [dependencies]
 libc = "0.2.0"
-nom = "1.2.4"
+nom = {version = "^2.0", features = ["verbose-errors"]}
 log = "*"
 env_logger = "*"


### PR DESCRIPTION
Hi!

as a part of the release process for nom 2.0, I selected a few crates to test it with, and make sure everything works correctly.

Since your crate uses nom 1.0's error management, I added the "verbose-errors" compilation feature to keep compatibility. Otherwise, you're good to go!

If you want more information on this release, see the blogpost: https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/ (reddit discussion: https://www.reddit.com/r/rust/comments/5espfm/this_year_in_nom_20_is_here/ )

There are new features that could be of interest for this project :)