### PR TITLE
Handle BER/DER tags that are longer than one byte.

### DIFF
--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -8,7 +8,7 @@ use oid::Oid;
 
 /// Defined in X.680 section 8.4
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct BerTag(pub u8);
+pub struct BerTag(pub u32);
 
 newtype_enum!{
 impl debug BerTag {

--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -7,6 +7,8 @@ use std::convert::AsRef;
 use oid::Oid;
 
 /// Defined in X.680 section 8.4
+/// X.690 doesn't specify the maxmimum tag size so we're assuming that people
+/// aren't going to need anything more than a u32.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct BerTag(pub u32);
 

--- a/src/ber/parser.rs
+++ b/src/ber/parser.rs
@@ -32,6 +32,17 @@ pub(crate) fn parse_identifier(i: &[u8]) -> IResult<&[u8], (u8, u8, u32)> {
         if c == 0x1f {
             c = 0;
             loop {
+                // Make sure we don't read past the end of our data.
+                error_if!(
+                    i,
+                    tag_byte_count >= i.len(),
+                    ErrorKind::Custom(BER_TAG_ERROR)
+                )?;
+
+                // With tag defined as u32 the most we can fit in is four tag bytes.
+                // (X.690 doesn't actually specify maximum tag width.)
+                error_if!(i, tag_byte_count > 5, ErrorKind::Custom(BER_TAG_ERROR))?;
+
                 c = (c << 7) | ((i[tag_byte_count] as u32) & 0x7f);
                 let done = i[tag_byte_count] & 0x80 == 0;
                 tag_byte_count += 1;

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -86,7 +86,6 @@ fn test_unknown_long_tag() {
 #[test]
 fn test_unknown_longer_tag() {
     let bytes = hex!("9f a2 22 01 00");
-    println!("{:?}", parse_ber(&bytes));
     let res = parse_ber(&bytes).expect("parsing failed");
     assert!(res.0.is_empty());
     assert_eq!(
@@ -98,6 +97,20 @@ fn test_unknown_longer_tag() {
             content: BerObjectContent::Unknown(BerTag(0x1122), &bytes[4..])
         }
     );
+}
+
+#[test]
+fn test_incomplete_tag() {
+    let bytes = hex!("9f a2 a2");
+    let res = parse_ber(&bytes);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_overflow_tag() {
+    let bytes = hex!("9f a2 a2 a2 a2 a2 22 01 00");
+    let res = parse_ber(&bytes);
+    assert!(res.is_err());
 }
 
 #[test]

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -36,13 +36,19 @@ fn test_rel_oid() {
 
 #[test]
 fn test_unknown_tag() {
-    let bytes = hex!("1f 01 00");
+    let bytes = hex!("1d 01 00");
     let res = parse_ber(&bytes).expect("parsing failed");
     assert!(res.0.is_empty());
-    assert_eq!(res.1, BerObject::from_obj(BerObjectContent::Unknown(BerTag(0x1f), &bytes[2..])));
+    assert_eq!(
+        res.1,
+        BerObject::from_obj(BerObjectContent::Unknown(BerTag(0x1d), &bytes[2..]))
+    );
     let res = parse_der(&bytes).expect("parsing failed");
     assert!(res.0.is_empty());
-    assert_eq!(res.1, BerObject::from_obj(BerObjectContent::Unknown(BerTag(0x1f), &bytes[2..])));
+    assert_eq!(
+        res.1,
+        BerObject::from_obj(BerObjectContent::Unknown(BerTag(0x1d), &bytes[2..]))
+    );
 }
 
 #[test]
@@ -50,12 +56,48 @@ fn test_unknown_context_specific() {
     let bytes = hex!("80 01 00");
     let res = parse_ber(&bytes).expect("parsing failed");
     assert!(res.0.is_empty());
-    assert_eq!(res.1, BerObject{
-        class: 2,
-        structured: 0,
-        tag: BerTag(0),
-        content: BerObjectContent::Unknown(BerTag(0x0), &bytes[2..])
-    });
+    assert_eq!(
+        res.1,
+        BerObject {
+            class: 2,
+            structured: 0,
+            tag: BerTag(0),
+            content: BerObjectContent::Unknown(BerTag(0x0), &bytes[2..])
+        }
+    );
+}
+
+#[test]
+fn test_unknown_long_tag() {
+    let bytes = hex!("9f 22 01 00");
+    let res = parse_ber(&bytes).expect("parsing failed");
+    assert!(res.0.is_empty());
+    assert_eq!(
+        res.1,
+        BerObject {
+            class: 2,
+            structured: 0,
+            tag: BerTag(0x22),
+            content: BerObjectContent::Unknown(BerTag(0x22), &bytes[3..])
+        }
+    );
+}
+
+#[test]
+fn test_unknown_longer_tag() {
+    let bytes = hex!("9f a2 22 01 00");
+    println!("{:?}", parse_ber(&bytes));
+    let res = parse_ber(&bytes).expect("parsing failed");
+    assert!(res.0.is_empty());
+    assert_eq!(
+        res.1,
+        BerObject {
+            class: 2,
+            structured: 0,
+            tag: BerTag(0x1122),
+            content: BerObjectContent::Unknown(BerTag(0x1122), &bytes[4..])
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
X.690 8.1.2 describes the encoding rules for tags including those that are
greater than (decimal) 30. The current code supports the format for values
up to 30 but mistakenly uses 31 (0x1f) as an "unknown" tag value in tests
while encoding it incorrectly and fails to support larger tags.

This change fixes both of these issues.