### PR TITLE
Upgrade num-bigint with range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ all-features = true
 [dependencies]
 nom = "5.0"
 rusticata-macros = "2.0.2"
-num-bigint = { version = "0.2", optional = true }
+num-bigint = { version = ">=0.2, <0.5", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
Trying to use this crate with [rsa](https://crates.io/crates/rsa/) which links num-bigint 0.4.

This should hopefully be a backwards-compatible change while allowing newer versions.