### PR TITLE
Fix DER datestring sanity check

### DIFF
--- a/src/der/parser.rs
+++ b/src/der/parser.rs
@@ -303,7 +303,7 @@ pub fn der_read_element_content_as(
         | BerTag::GeneralString => {
             der_constraint_fail_if!(i, constructed);
         }
-        BerTag::UtcTime | BerTag::GeneralizedTime => match i.last() {
+        BerTag::UtcTime | BerTag::GeneralizedTime => match i.get(len - 1) {
             Some(b'Z') => (),
             _ => {
                 return Err(Err::Error(BerError::DerConstraintFailed));

--- a/src/der/parser.rs
+++ b/src/der/parser.rs
@@ -303,12 +303,11 @@ pub fn der_read_element_content_as(
         | BerTag::GeneralString => {
             der_constraint_fail_if!(i, constructed);
         }
-        BerTag::UtcTime | BerTag::GeneralizedTime => match i.get(len - 1) {
-            Some(b'Z') => (),
-            _ => {
+        BerTag::UtcTime | BerTag::GeneralizedTime => {
+            if len == 0 || i.get(len - 1).copied() != Some(b'Z') {
                 return Err(Err::Error(BerError::DerConstraintFailed));
             }
-        },
+        }
         _ => (),
     }
     ber_read_element_content_as(i, tag, len, constructed, depth)

--- a/tests/der_parser.rs
+++ b/tests/der_parser.rs
@@ -239,9 +239,9 @@ fn test_der_set_of() {
 #[test]
 fn test_der_utctime() {
     let empty = &b""[..];
-    let bytes = hex!("17 0D 30 32 31 32 31 33 31 34 32 39 32 33 5A");
-    let expected = DerObject::from_obj(BerObjectContent::UTCTime(&bytes[2..]));
-    assert_eq!(parse_der_utctime(&bytes), Ok((empty, expected)));
+    let bytes = hex!("17 0D 30 32 31 32 31 33 31 34 32 39 32 33 5A FF");
+    let expected = DerObject::from_obj(BerObjectContent::UTCTime(&bytes[2..(2 + 0x0d)]));
+    assert_eq!(parse_der_utctime(&bytes), Ok((&[0xff][..], expected)));
     let bytes = hex!("17 0c 30 32 31 32 31 33 31 34 32 39 32 33");
     parse_der_utctime(&bytes).err().expect("expected error");
 }


### PR DESCRIPTION
This PR fixes a bug in which datestring parsing fails when there are bytes after the datestring.