### PR TITLE
fix/add-support-for-to_u64-for-bit-string: Make .as_u64 and .as_u32 work for objects of type BIT STRING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+- Implement the `as_u64` and `as_u32` methods for BerObjects with contents of type `BerObjectContent::BitString``
+
 ### Thanks
 
 ### Added

--- a/src/ber/parser.rs
+++ b/src/ber/parser.rs
@@ -32,7 +32,10 @@ pub(crate) fn bytes_to_u64(s: &[u8]) -> Result<u64, BerError> {
 /// constructed BER encoding for BIT STRING does not seem to be
 /// supported at all by the library currently.
 #[inline]
-pub(crate) fn bitstring_to_u64(padding_bits: usize, data: &BitStringObject) -> Result<u64, BerError> {
+pub(crate) fn bitstring_to_u64(
+    padding_bits: usize,
+    data: &BitStringObject,
+) -> Result<u64, BerError> {
     let raw_bytes = data.data;
     let bit_size = raw_bytes.len() * 8 - padding_bits;
     if bit_size > 64 {
@@ -45,7 +48,6 @@ pub(crate) fn bitstring_to_u64(padding_bits: usize, data: &BitStringObject) -> R
     }
     Ok(resulting_integer >> padding_bits)
 }
-
 
 pub(crate) fn parse_identifier(i: &[u8]) -> BerResult<(u8, u8, u32, &[u8])> {
     if i.is_empty() {

--- a/src/der/parser.rs
+++ b/src/der/parser.rs
@@ -130,6 +130,21 @@ pub fn parse_der_integer(i: &[u8]) -> DerResult {
 }
 
 /// Read an bitstring value
+///
+/// To access the content as plain bytes, you will have to
+/// interprete the resulting tuple which will contain in
+/// its first item the number of padding bits left at
+/// the end of the bit string, and in its second item
+/// a `BitStringObject` structure which will, in its sole
+/// structure field called `data`, contain a byte slice
+/// representing the value of the bit string which can
+/// be interpreted as a big-endian value with the padding
+/// bits on the right (as in ASN.1 raw BER or DER encoding).
+///
+/// To access the content as an integer, use the [`as_u64`](struct.BerObject.html#method.as_u64)
+/// or [`as_u32`](struct.BerObject.html#method.as_u32) methods.
+/// Remember that a BER bit string has unlimited size, so these methods return `Result` or `Option`
+/// objects.
 pub fn parse_der_bitstring(i: &[u8]) -> DerResult {
     do_parse! {
         i,


### PR DESCRIPTION
This pull request will implement the fix for issue #28 and add the corresponding tests and documentation.