### PR TITLE
fix/update-nom-to-5.1.x: Update the "nom" dependency to 5.1.x so that nom::Err can correctly inherit std::error::Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 cookie-factory = { version="0.3.0", optional=true }
-nom = "5.0"
+nom = "5.1"
 rusticata-macros = "2.0.2"
 num-traits = "0.2"
 num-bigint = { version = "0.3", optional = true }


### PR DESCRIPTION
This pull request will update the "nom" dependency to 5.1.x so that [`nom::Err`](https://docs.rs/nom/5.1.2/nom/enum.Err.html) can correctly inherit [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html), following this commit: https://github.com/Geal/nom/commit/7952b6909e2e6d315fe6344d14fad084fe98bf89

This is useful because it allows users, when mixing nom function calls with non-nom function calls, to use a generic `Result<T, Box<dyn Error>>` return type and to use the [`?` error handling operator](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/the-question-mark-operator-for-easier-error-handling.html), which makes the code way more readable.