### PR TITLE
fix/add-support-for-advanced-string-types: Add support for string types such as VideotexString, ObjectDescriptor, GraphicString, and VisibleString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased][unreleased]
 
-- Implement the `as_u64` and `as_u32` methods for BerObjects with contents of type `BerObjectContent::BitString``
+- Implement the `as_u64` and `as_u32` methods for BerObjects with contents of type `BerObjectContent::BitString`.
+- Implement the `VideotexString`, `ObjectDescriptor` `GraphicString`, and `VisibleString` string types. (Non-breaking changes)
+- Correctly decode `BMPString` as UTF-16 instead of UTF-8 when printing. (Non-breaking change)
 
 ### Thanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Implement the `as_u64` and `as_u32` methods for BerObjects with contents of type `BerObjectContent::BitString`.
 - Implement the `VideotexString`, `ObjectDescriptor` `GraphicString`, and `VisibleString` string types. (Non-breaking changes)
 - Correctly decode `BMPString` as UTF-16 instead of UTF-8 when printing. (Non-breaking change)
+- Turn `UTCTime` and `GeneralizedTime` into a `&str` instead of `&[u8]`, as they inherit from `VisibleString` which is a subset of ASCII. (Breaking change)
 
 ### Thanks
 

--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -50,13 +50,17 @@ impl debug BerTag {
     NumericString = 0x12,
     PrintableString = 0x13,
     T61String = 0x14,
+    VideotexString = 0x15,
 
     Ia5String = 0x16,
     UtcTime = 0x17,
     GeneralizedTime = 0x18,
 
+    GraphicString = 15, // 0x19
+    VisibleString = 26, // 0x1a
     GeneralString = 27, // 0x1b
 
+    UniversalString = 0x1c,
     BmpString = 0x1e,
 
     Invalid = 0xff,
@@ -92,12 +96,15 @@ pub enum BerObjectContent<'a> {
     OID(Oid<'a>),
     RelativeOID(Oid<'a>),
     NumericString(&'a str),
+    VisibleString(&'a str),
     PrintableString(&'a str),
     IA5String(&'a str),
     UTF8String(&'a str),
     T61String(&'a [u8]),
+    VideotexString(&'a [u8]),
 
     BmpString(&'a [u8]),
+    UniversalString(&'a [u8]),
 
     Sequence(Vec<BerObject<'a>>),
     Set(Vec<BerObject<'a>>),
@@ -105,6 +112,8 @@ pub enum BerObjectContent<'a> {
     UTCTime(&'a [u8]),
     GeneralizedTime(&'a [u8]),
 
+    ObjectDescriptor(&'a [u8]),
+    GraphicString(&'a [u8]),
     GeneralString(&'a [u8]),
 
     ContextSpecific(BerTag, Option<Box<BerObject<'a>>>),
@@ -351,8 +360,9 @@ impl<'a> BerObject<'a> {
     /// Attempt to get the content from a DER object, as a str.
     /// This can fail if the object does not contain a string type.
     ///
-    /// Only NumericString, PrintableString, UTF8String and IA5String
-    /// are considered here. Other string types can be read using `as_slice`.
+    /// Only NumericString, VisibleString, PrintableString, UTF8String and
+    /// IA5String are considered here. Other string types can be read using
+    /// `as_slice`.
     pub fn as_str(&self) -> Result<&'a str, BerError> {
         self.content.as_str()
     }
@@ -531,6 +541,7 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_slice(&self) -> Result<&'a [u8],BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
+            BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::UTF8String(s) |
             BerObjectContent::IA5String(s) => Ok(s.as_ref()),
@@ -538,7 +549,11 @@ impl<'a> BerObjectContent<'a> {
             BerObjectContent::BitString(_,BitStringObject{data:s}) |
             BerObjectContent::OctetString(s) |
             BerObjectContent::T61String(s) |
+            BerObjectContent::VideotexString(s) |
             BerObjectContent::BmpString(s) |
+            BerObjectContent::UniversalString(s) |
+            BerObjectContent::ObjectDescriptor(s) |
+            BerObjectContent::GraphicString(s) |
             BerObjectContent::GeneralString(s) |
             BerObjectContent::Unknown(_,s) => Ok(s),
             _ => Err(BerError::BerTypeError),
@@ -549,6 +564,7 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_str(&self) -> Result<&'a str,BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
+            BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::UTF8String(s) |
             BerObjectContent::IA5String(s) => Ok(s),
@@ -568,16 +584,21 @@ impl<'a> BerObjectContent<'a> {
             BerObjectContent::Enum(_)              => BerTag::Enumerated,
             BerObjectContent::OID(_)               => BerTag::Oid,
             BerObjectContent::NumericString(_)     => BerTag::NumericString,
+            BerObjectContent::VisibleString(_)     => BerTag::VisibleString,
             BerObjectContent::PrintableString(_)   => BerTag::PrintableString,
             BerObjectContent::IA5String(_)         => BerTag::Ia5String,
             BerObjectContent::UTF8String(_)        => BerTag::Utf8String,
             BerObjectContent::RelativeOID(_)       => BerTag::RelativeOid,
             BerObjectContent::T61String(_)         => BerTag::T61String,
+            BerObjectContent::VideotexString(_)    => BerTag::VideotexString,
             BerObjectContent::BmpString(_)         => BerTag::BmpString,
+            BerObjectContent::UniversalString(_)   => BerTag::UniversalString,
             BerObjectContent::Sequence(_)          => BerTag::Sequence,
             BerObjectContent::Set(_)               => BerTag::Set,
             BerObjectContent::UTCTime(_)           => BerTag::UtcTime,
             BerObjectContent::GeneralizedTime(_)   => BerTag::GeneralizedTime,
+            BerObjectContent::ObjectDescriptor(_)  => BerTag::ObjDescriptor,
+            BerObjectContent::GraphicString(_)     => BerTag::GraphicString,
             BerObjectContent::GeneralString(_)     => BerTag::GeneralString,
             BerObjectContent::ContextSpecific(x,_) |
             BerObjectContent::Unknown(x,_)         => x,

--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -109,8 +109,8 @@ pub enum BerObjectContent<'a> {
     Sequence(Vec<BerObject<'a>>),
     Set(Vec<BerObject<'a>>),
 
-    UTCTime(&'a [u8]),
-    GeneralizedTime(&'a [u8]),
+    UTCTime(&'a str),
+    GeneralizedTime(&'a str),
 
     ObjectDescriptor(&'a [u8]),
     GraphicString(&'a [u8]),
@@ -360,9 +360,9 @@ impl<'a> BerObject<'a> {
     /// Attempt to get the content from a DER object, as a str.
     /// This can fail if the object does not contain a string type.
     ///
-    /// Only NumericString, VisibleString, PrintableString, UTF8String and
-    /// IA5String are considered here. Other string types can be read using
-    /// `as_slice`.
+    /// Only NumericString, VisibleString, UTCTime, GeneralizedTime,
+    /// PrintableString, UTF8String and IA5String are considered here. Other
+    /// string types can be read using `as_slice`.
     pub fn as_str(&self) -> Result<&'a str, BerError> {
         self.content.as_str()
     }
@@ -541,6 +541,8 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_slice(&self) -> Result<&'a [u8],BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
+            BerObjectContent::GeneralizedTime(s) |
+            BerObjectContent::UTCTime(s) |
             BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::UTF8String(s) |
@@ -564,6 +566,8 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_str(&self) -> Result<&'a str,BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
+            BerObjectContent::GeneralizedTime(s) |
+            BerObjectContent::UTCTime(s) |
             BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::UTF8String(s) |

--- a/src/ber/parser.rs
+++ b/src/ber/parser.rs
@@ -274,6 +274,25 @@ fn ber_read_content_numericstring<'a>(i: &'a [u8], len: usize) -> BerResult<BerO
     })
 }
 
+fn ber_read_content_visiblestring<'a>(
+    i: &'a [u8],
+    len: usize, 
+) -> BerResult<BerObjectContent<'a>> {
+    // Argument must be a reference, because of the .iter().all(F) call below
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    fn is_visible(b: &u8) -> bool {
+        0x20 <= *b && *b <= 0x7f
+    }
+    map_res!(i, take!(len), |bytes: &'a [u8]| {
+        if !bytes.iter().all(is_visible) {
+            return Err(BerError::BerValueError);
+        }
+        std::str::from_utf8(bytes)
+            .map(|s| BerObjectContent::VisibleString(s))
+            .map_err(|_| BerError::BerValueError)
+    })
+}
+
 fn ber_read_content_printablestring<'a>(
     i: &'a [u8],
     len: usize,
@@ -315,6 +334,11 @@ fn ber_read_content_t61string(i: &[u8], len: usize) -> BerResult<BerObjectConten
     map(take(len), BerObjectContent::T61String)(i)
 }
 
+#[inline]
+fn ber_read_content_videotexstring(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
+    map(take(len), BerObjectContent::VideotexString)(i)
+}
+
 fn ber_read_content_ia5string<'a>(i: &'a [u8], len: usize) -> BerResult<BerObjectContent<'a>> {
     map_res(take(len), |bytes: &'a [u8]| {
         if !bytes.iter().all(u8::is_ascii) {
@@ -337,6 +361,16 @@ fn ber_read_content_generalizedtime(i: &[u8], len: usize) -> BerResult<BerObject
 }
 
 #[inline]
+fn ber_read_content_objectdescriptor(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
+    map(take(len), BerObjectContent::ObjectDescriptor)(i)
+}
+
+#[inline]
+fn ber_read_content_graphicstring(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
+    map(take(len), BerObjectContent::GraphicString)(i)
+}
+
+#[inline]
 fn ber_read_content_generalstring(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
     map(take(len), BerObjectContent::GeneralString)(i)
 }
@@ -344,6 +378,11 @@ fn ber_read_content_generalstring(i: &[u8], len: usize) -> BerResult<BerObjectCo
 #[inline]
 fn ber_read_content_bmpstring(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
     map(take(len), BerObjectContent::BmpString)(i)
+}
+
+#[inline]
+fn ber_read_content_universalstring(i: &[u8], len: usize) -> BerResult<BerObjectContent> {
+    map(take(len), BerObjectContent::UniversalString)(i)
 }
 
 /// Parse the next bytes as the content of a BER object.
@@ -391,17 +430,24 @@ pub fn ber_read_element_content_as(
             custom_check!(i, len != 0, BerError::InvalidLength)?;
             ber_read_content_null(i)
         }
-        // 0x06: object identified
+        // 0x06: object identifier
         BerTag::Oid => {
             custom_check!(i, constructed, BerError::ConstructUnexpected)?; // forbidden in 8.19.1
             ber_read_content_oid(i, len)
+        }
+        // 0x07: object descriptor - Alias for GraphicString with a different
+        // implicit tag, see below
+        BerTag::ObjDescriptor => {
+            custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
+            ber_read_content_objectdescriptor(i, len)
         }
         // 0x0a: enumerated
         BerTag::Enumerated => {
             custom_check!(i, constructed, BerError::ConstructUnexpected)?; // forbidden in 8.4
             ber_read_content_enum(i, len)
         }
-        // 0x0c: UTF8String
+        // 0x0c: UTF8String - Unicode encoded with the UTF-8 charset (ISO/IEC
+        // 10646-1, Annex D)
         BerTag::Utf8String => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_utf8string(i, len)
@@ -421,39 +467,72 @@ pub fn ber_read_element_content_as(
             custom_check!(i, !constructed, BerError::ConstructExpected)?;
             ber_read_content_set(i, len, max_depth)
         }
-        // 0x12: numericstring
+        // 0x12: numericstring - ASCII string with digits an spaces only
         BerTag::NumericString => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_numericstring(i, len)
         }
-        // 0x13: printablestring
+        // 0x13: printablestring - ASCII string with certain printable
+        // characters only (specified in Table 10 of X.680)
         BerTag::PrintableString => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_printablestring(i, len)
         }
-        // 0x14: t61string
+        // 0x14: t61string - ISO 2022 string with a Teletex (T.61) charset,
+        // ASCII is possible but only when explicit escaped, as by default
+        // the G0 character range (0x20-0x7f) will match the graphic character
+        // set. https://en.wikipedia.org/wiki/ITU_T.61
         BerTag::T61String => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_t61string(i, len)
         }
-        // 0x16: ia5string
+        // 0x15: videotexstring - ISO 2022 string with a Videotex (T.100/T.101)
+        // charset, excluding ASCII. https://en.wikipedia.org/wiki/Videotex_character_set
+        BerTag::VideotexString => {
+            custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
+            ber_read_content_videotexstring(i, len)
+        }
+        // 0x16: ia5string - ASCII string
         BerTag::Ia5String => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_ia5string(i, len)
         }
-        // 0x17: utctime
+        // 0x17: utctime - Alias for a VisibleString with a different implicit
+        // tag, see below
         BerTag::UtcTime => ber_read_content_utctime(i, len),
-        // 0x18: generalizedtime
+        // 0x18: generalizedtime - Alias for a VisibleString with a different
+        // implicit tag, see below
         BerTag::GeneralizedTime => ber_read_content_generalizedtime(i, len),
-        // 0x1b: generalstring
+        // 0x19: graphicstring - Generic ISO 2022 container with explicit
+        // escape sequences, without control characters
+        BerTag::GraphicString => {
+            custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
+            ber_read_content_graphicstring(i, len)
+        }
+        // 0x1a: visiblestring - ASCII string with no control characters except
+        // SPACE
+        BerTag::VisibleString => {
+            custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
+            ber_read_content_visiblestring(i, len)
+        }
+        // 0x1b: generalstring - Generic ISO 2022 container with explicit
+        // escape sequences
         BerTag::GeneralString => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_generalstring(i, len)
         }
-        // 0x1e: bmpstring
+        // 0x1e: bmpstring - Unicode encoded with the UCS-2 big-endian charset
+        // (ISO/IEC 10646-1, section 13.1), restricted to the BMP (Basic
+        // Multilingual Plane) except certain control cahracters
         BerTag::BmpString => {
             custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
             ber_read_content_bmpstring(i, len)
+        }
+        // 0x1c: universalstring - Unicode encoded with the UCS-4 big-endian
+        // charset (ISO/IEC 10646-1, section 13.2)
+        BerTag::UniversalString => {
+            custom_check!(i, constructed, BerError::Unsupported)?; // XXX valid in BER (8.21)
+            ber_read_content_universalstring(i, len)
         }
         // all unknown values
         _ => Err(Err::Error(BerError::UnknownTag)),
@@ -631,6 +710,13 @@ pub fn parse_ber_numericstring(i: &[u8]) -> BerResult {
     parse_ber_with_tag(i, BerTag::NumericString)
 }
 
+/// Read a visible string value. The content is verified to
+/// contain only the allowed characters.
+#[inline]
+pub fn parse_ber_visiblestring(i: &[u8]) -> BerResult {
+    parse_ber_with_tag(i, BerTag::VisibleString)
+}
+
 /// Read a printable string value. The content is verified to
 /// contain only the allowed characters.
 #[inline]
@@ -642,6 +728,12 @@ pub fn parse_ber_printablestring(i: &[u8]) -> BerResult {
 #[inline]
 pub fn parse_ber_t61string(i: &[u8]) -> BerResult {
     parse_ber_with_tag(i, BerTag::T61String)
+}
+
+/// Read a Videotex string value
+#[inline]
+pub fn parse_ber_videotexstring(i: &[u8]) -> BerResult {
+    parse_ber_with_tag(i, BerTag::VideotexString)
 }
 
 /// Read an IA5 string value. The content is verified to be ASCII.
@@ -662,6 +754,18 @@ pub fn parse_ber_generalizedtime(i: &[u8]) -> BerResult {
     parse_ber_with_tag(i, BerTag::GeneralizedTime)
 }
 
+/// Read an ObjectDescriptor value
+#[inline]
+pub fn parse_ber_objectdescriptor(i: &[u8]) -> BerResult {
+    parse_ber_with_tag(i, BerTag::ObjDescriptor)
+}
+
+/// Read a GraphicString value
+#[inline]
+pub fn parse_ber_graphicstring(i: &[u8]) -> BerResult {
+    parse_ber_with_tag(i, BerTag::GraphicString)
+}
+
 /// Read a GeneralString value
 #[inline]
 pub fn parse_ber_generalstring(i: &[u8]) -> BerResult {
@@ -672,6 +776,12 @@ pub fn parse_ber_generalstring(i: &[u8]) -> BerResult {
 #[inline]
 pub fn parse_ber_bmpstring(i: &[u8]) -> BerResult {
     parse_ber_with_tag(i, BerTag::BmpString)
+}
+
+/// Read a UniversalString value
+#[inline]
+pub fn parse_ber_universalstring(i: &[u8]) -> BerResult {
+    parse_ber_with_tag(i, BerTag::UniversalString)
 }
 
 pub fn parse_ber_explicit_failed(i: &[u8], tag: BerTag) -> BerResult {
@@ -842,6 +952,22 @@ fn test_numericstring() {
 }
 
 #[test]
+fn text_visiblestring() {
+    assert_eq!(
+        ber_read_content_visiblestring(b"AZaz]09 '()+,-./:=?", 19),
+        Ok((
+            [].as_ref(),
+            BerObjectContent::VisibleString("AZaz]09 '()+,-./:=?")
+        )),
+    );
+    assert_eq!(
+        ber_read_content_visiblestring(b"", 0),
+        Ok(([].as_ref(), BerObjectContent::VisibleString(""))),
+    );
+    assert!(ber_read_content_visiblestring(b"\n", 1).is_err());
+}
+
+#[test]
 fn test_printablestring() {
     assert_eq!(
         ber_read_content_printablestring(b"AZaz09 '()+,-./:=?", 18),
@@ -854,16 +980,16 @@ fn test_printablestring() {
         ber_read_content_printablestring(b"", 0),
         Ok(([].as_ref(), BerObjectContent::PrintableString(""))),
     );
-    assert!(ber_read_content_printablestring(b"]", 1).is_err());
+    assert!(ber_read_content_printablestring(b"]\n", 2).is_err());
 }
 
 #[test]
 fn test_ia5string() {
     assert_eq!(
-        ber_read_content_ia5string(b"AZaz09 '()+,-./:=?[]{}\0\n", 24),
+        ber_read_content_ia5string(b"AZaz\n09 '()+,-./:=?[]{}\0\n", 25),
         Ok((
             [].as_ref(),
-            BerObjectContent::IA5String("AZaz09 '()+,-./:=?[]{}\0\n")
+            BerObjectContent::IA5String("AZaz\n09 '()+,-./:=?[]{}\0\n")
         )),
     );
     assert_eq!(

--- a/src/ber/print.rs
+++ b/src/ber/print.rs
@@ -96,8 +96,8 @@ impl<'a> fmt::Debug for PrettyBer<'a> {
             BerObjectContent::OctetString(v)         => writeln!(f, "OctetString({:?})", debug::HexSlice(v)),
             BerObjectContent::BitString(u,BitStringObject{data:v})
                                                      => writeln!(f, "BitString({},{:?})", u, debug::HexSlice(v)),
-            BerObjectContent::GeneralizedTime(s)     => print_utf8_string_with_type(f, s, "GeneralizedTime"),
-            BerObjectContent::UTCTime(s)             => print_utf8_string_with_type(f, s, "UTCTime"),
+            BerObjectContent::GeneralizedTime(s)     => writeln!(f, "GeneralizedTime(\"{}\")", s),
+            BerObjectContent::UTCTime(s)             => writeln!(f, "UTCTime(\"{}\")", s),
             BerObjectContent::VisibleString(s)       => writeln!(f, "VisibleString(\"{}\")", s),
             BerObjectContent::PrintableString(s)     => writeln!(f, "PrintableString(\"{}\")", s),
             BerObjectContent::NumericString(s)       => writeln!(f, "NumericString(\"{}\")", s),

--- a/src/ber/serialize.rs
+++ b/src/ber/serialize.rs
@@ -130,11 +130,16 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
         }
         BerObjectContent::OID(oid) | BerObjectContent::RelativeOID(oid) => ber_encode_oid(oid)(out),
         BerObjectContent::NumericString(s)
+        | BerObjectContent::VisibleString(s)
         | BerObjectContent::PrintableString(s)
         | BerObjectContent::IA5String(s)
         | BerObjectContent::UTF8String(s) => slice(s)(out),
         BerObjectContent::T61String(s)
+        | BerObjectContent::VideotexString(s)
         | BerObjectContent::BmpString(s)
+        | BerObjectContent::UniversalString(s)
+        | BerObjectContent::ObjectDescriptor(s)
+        | BerObjectContent::GraphicString(s)
         | BerObjectContent::GeneralString(s)
         | BerObjectContent::UTCTime(s)
         | BerObjectContent::GeneralizedTime(s) => slice(s)(out),

--- a/src/ber/serialize.rs
+++ b/src/ber/serialize.rs
@@ -130,6 +130,8 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
         }
         BerObjectContent::OID(oid) | BerObjectContent::RelativeOID(oid) => ber_encode_oid(oid)(out),
         BerObjectContent::NumericString(s)
+        | BerObjectContent::UTCTime(s)
+        | BerObjectContent::GeneralizedTime(s)
         | BerObjectContent::VisibleString(s)
         | BerObjectContent::PrintableString(s)
         | BerObjectContent::IA5String(s)
@@ -140,9 +142,7 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
         | BerObjectContent::UniversalString(s)
         | BerObjectContent::ObjectDescriptor(s)
         | BerObjectContent::GraphicString(s)
-        | BerObjectContent::GeneralString(s)
-        | BerObjectContent::UTCTime(s)
-        | BerObjectContent::GeneralizedTime(s) => slice(s)(out),
+        | BerObjectContent::GeneralString(s) => slice(s)(out),
         BerObjectContent::Sequence(v) | BerObjectContent::Set(v) => ber_encode_sequence(&v)(out),
         // best we can do is tagged-explicit, but we don't know
         BerObjectContent::ContextSpecific(_tag, opt_inner) => {

--- a/src/der/parser.rs
+++ b/src/der/parser.rs
@@ -228,6 +228,13 @@ pub fn parse_der_numericstring(i: &[u8]) -> DerResult {
 /// Read a printable string value. The content is verified to
 /// contain only the allowed characters.
 #[inline]
+pub fn visiblestring(i: &[u8]) -> DerResult {
+    parse_der_with_tag(i, BerTag::VisibleString)
+}
+
+/// Read a printable string value. The content is verified to
+/// contain only the allowed characters.
+#[inline]
 pub fn parse_der_printablestring(i: &[u8]) -> DerResult {
     parse_der_with_tag(i, BerTag::PrintableString)
 }
@@ -236,6 +243,12 @@ pub fn parse_der_printablestring(i: &[u8]) -> DerResult {
 #[inline]
 pub fn parse_der_t61string(i: &[u8]) -> DerResult {
     parse_der_with_tag(i, BerTag::T61String)
+}
+
+/// Read a Videotex string value
+#[inline]
+pub fn parse_der_videotexstring(i: &[u8]) -> DerResult {
+    parse_der_with_tag(i, BerTag::VideotexString)
 }
 
 /// Read an IA5 string value. The content is verified to be ASCII.
@@ -256,6 +269,18 @@ pub fn parse_der_generalizedtime(i: &[u8]) -> DerResult {
     parse_der_with_tag(i, BerTag::GeneralizedTime)
 }
 
+/// Read a ObjectDescriptor value
+#[inline]
+pub fn parse_der_objectdescriptor(i: &[u8]) -> DerResult {
+    parse_der_with_tag(i, BerTag::ObjDescriptor)
+}
+
+/// Read a GraphicString value
+#[inline]
+pub fn parse_der_graphicstring(i: &[u8]) -> DerResult {
+    parse_der_with_tag(i, BerTag::GraphicString)
+}
+
 /// Read a GeneralString value
 #[inline]
 pub fn parse_der_generalstring(i: &[u8]) -> DerResult {
@@ -266,6 +291,12 @@ pub fn parse_der_generalstring(i: &[u8]) -> DerResult {
 #[inline]
 pub fn parse_der_bmpstring(i: &[u8]) -> DerResult {
     parse_der_with_tag(i, BerTag::BmpString)
+}
+
+/// Read a UniversalString value
+#[inline]
+pub fn parse_der_universalstring(i: &[u8]) -> DerResult {
+    parse_der_with_tag(i, BerTag::UniversalString)
 }
 
 /// Parse an optional tagged object, applying function to get content
@@ -373,11 +404,16 @@ pub fn der_read_element_content_as(
             return der_read_content_bitstring(i, len);
         }
         BerTag::NumericString
+        | BerTag::VisibleString
         | BerTag::PrintableString
         | BerTag::Ia5String
         | BerTag::Utf8String
         | BerTag::T61String
+        | BerTag::VideotexString
         | BerTag::BmpString
+        | BerTag::UniversalString
+        | BerTag::ObjDescriptor
+        | BerTag::GraphicString
         | BerTag::GeneralString => {
             der_constraint_fail_if!(i, constructed);
         }

--- a/tests/der_parser.rs
+++ b/tests/der_parser.rs
@@ -239,7 +239,9 @@ fn test_der_set_of() {
 #[test]
 fn test_der_utctime() {
     let bytes = hex!("17 0D 30 32 31 32 31 33 31 34 32 39 32 33 5A FF");
-    let expected = DerObject::from_obj(BerObjectContent::UTCTime(&bytes[2..(2 + 0x0d)]));
+    let expected = DerObject::from_obj(BerObjectContent::UTCTime(
+        std::str::from_utf8(&bytes[2..(2 + 0x0d)]).unwrap(),
+    ));
     assert_eq!(parse_der_utctime(&bytes), Ok((&[0xff][..], expected)));
     let bytes = hex!("17 0c 30 32 31 32 31 33 31 34 32 39 32 33");
     parse_der_utctime(&bytes).err().expect("expected error");
@@ -251,7 +253,9 @@ fn test_der_generalizedtime() {
     let bytes = [
         0x18, 0x0D, 0x30, 0x32, 0x31, 0x32, 0x31, 0x33, 0x31, 0x34, 0x32, 0x39, 0x32, 0x33, 0x5A,
     ];
-    let expected = DerObject::from_obj(BerObjectContent::GeneralizedTime(&bytes[2..]));
+    let expected = DerObject::from_obj(BerObjectContent::GeneralizedTime(
+        std::str::from_utf8(&bytes[2..]).unwrap(),
+    ));
     assert_eq!(parse_der_generalizedtime(&bytes), Ok((empty, expected)));
 }
 


### PR DESCRIPTION
This pull request will:

- Implement the `VideotexString`, `ObjectDescriptor` `GraphicString`, and `VisibleString` string types. (Non-breaking changes)
- Correctly decode `BMPString` as UTF-16 instead of UTF-8 when printing. (Non-breaking change)
- Turn `UTCTime` and `GeneralizedTime` into a `&str` instead of `&[u8]`, as they inherit from `VisibleString` which is a subset of ASCII. (Breaking change)