### PR TITLE
fix/correctly-handle-oids-starting-with-two-zeroes: Correctly handle OIDs starting with two zero subidentifiers (literally "itu-t recommendation")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 - Implement the `as_u64` and `as_u32` methods for BerObjects with contents of type `BerObjectContent::BitString``
+- Fix the bug that caused OIDs longer than two subidentifiers which started by subidentifiers "0.0" ("itu-t recommenation") not to be decoded correctly
 
 ### Thanks
 

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -420,7 +420,6 @@ mod tests {
         assert_eq!(oid_ref, oid);
     }
 
-
     /// This test case will test an OID beginning with two zero
     /// subidentifiers (literally: "itu-t recommendation"), as
     /// used for example in the TCAP (Q.773) specification.

--- a/src/oid.rs
+++ b/src/oid.rs
@@ -279,7 +279,7 @@ impl<'a, N: Repr> Iterator for SubIdentifierIterator<'a, N> {
                 return Some((self.oid.asn1[0] / 40).into());
             } else if self.pos == 0 {
                 self.pos += 1;
-                if self.oid.asn1[0] == 0 {
+                if self.oid.asn1[0] == 0 && self.oid.asn1.len() == 1 {
                     return None;
                 }
                 return Some((self.oid.asn1[0] % 40).into());
@@ -418,6 +418,18 @@ mod tests {
         let oid = Oid::from_str("1.2.840.113549.1.1.5").unwrap();
         assert_eq!(byte_ref.as_ref(), oid.asn1.as_ref());
         assert_eq!(oid_ref, oid);
+    }
+
+
+    /// This test case will test an OID beginning with two zero
+    /// subidentifiers (literally: "itu-t recommendation"), as
+    /// used for example in the TCAP (Q.773) specification.
+
+    #[test]
+    fn test_itu_t_rec_oid() {
+        let oid = Oid::from(&[0, 0, 17, 773, 1, 1, 1]).unwrap();
+        assert_eq!(format!("{}", oid), "0.0.17.773.1.1.1".to_owned());
+        assert_eq!(format!("{:?}", oid), "OID(0.0.17.773.1.1.1)".to_owned());
     }
 
     #[test]


### PR DESCRIPTION
This pull request will allow to correctly handle OIDs starting with two zero subidentifiers (literally "itu-t recommendation").

Here in an example of such an OID definition from the ASN.1 definitions for the TCAP (Q.773) protocol:

```asn1
dialogue-as-id OBJECT IDENTIFIER ::=
  {itu-t recommendation q 773 as(1) dialogue-as(1) version1(1)}
```

Previously, they were incorrectly decoded or represented as just "0" due to a bug in the library (they were interpreted just as when they contained only one octet which was "`\x00`", which was alleged to mean "only one subidentifier being 0", because of a missing conditional check on the raw OID byte length in the code when handling this special case).

The corresponding test case was also added to the code so that the issue is ensured to be fixed.