### PR TITLE
Fix conversion of Integer to fixedints

### DIFF
--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -411,12 +411,7 @@ impl<'a> BerObjectContent<'a> {
     /// ```
     pub fn as_i64(&self) -> Result<i64, BerError> {
         if let BerObjectContent::Integer(bytes) = self {
-            let result = if is_highest_bit_set(bytes) {
-                <i64>::from_be_bytes(decode_array_int8(bytes)?)
-            } else {
-                <u64>::from_be_bytes(decode_array_uint8(bytes)?) as i64
-            };
-            Ok(result)
+            decode_array_int8(bytes)
         } else {
             Err(BerError::BerValueError)
         }
@@ -438,12 +433,7 @@ impl<'a> BerObjectContent<'a> {
     /// ```
     pub fn as_i32(&self) -> Result<i32, BerError> {
         if let BerObjectContent::Integer(bytes) = self {
-            let result = if is_highest_bit_set(bytes) {
-                <i32>::from_be_bytes(decode_array_int4(bytes)?)
-            } else {
-                <u32>::from_be_bytes(decode_array_uint4(bytes)?) as i32
-            };
-            Ok(result)
+            decode_array_int4(bytes)
         } else {
             Err(BerError::BerValueError)
         }
@@ -465,10 +455,7 @@ impl<'a> BerObjectContent<'a> {
     /// ```
     pub fn as_u64(&self) -> Result<u64, BerError> {
         match self {
-            BerObjectContent::Integer(i) => {
-                let result = <u64>::from_be_bytes(decode_array_uint8(i)?);
-                Ok(result)
-            }
+            BerObjectContent::Integer(i) => decode_array_uint8(i),
             BerObjectContent::BitString(ignored_bits, data) => {
                 bitstring_to_u64(*ignored_bits as usize, data)
             }
@@ -494,10 +481,7 @@ impl<'a> BerObjectContent<'a> {
     /// ```
     pub fn as_u32(&self) -> Result<u32, BerError> {
         match self {
-            BerObjectContent::Integer(i) => {
-                let result = <u32>::from_be_bytes(decode_array_uint4(i)?);
-                Ok(result)
-            }
+            BerObjectContent::Integer(i) => decode_array_uint4(i),
             BerObjectContent::BitString(ignored_bits, data) => {
                 bitstring_to_u64(*ignored_bits as usize, data).and_then(|x| {
                     if x > u64::from(core::u32::MAX) {

--- a/src/ber/integer.rs
+++ b/src/ber/integer.rs
@@ -1,123 +1,73 @@
 use crate::error::*;
 
-/// Decode an unsigned integer into a big endian byte slice with all leading
-/// zeroes removed.
-///
-/// Returns a byte array of the requested size containing a big endian integer.
-fn remove_zeroes(bytes: &[u8]) -> Result<&[u8], BerError> {
-    // skip leading 0s
-    match bytes {
-        // [] => Err(BerError::DerConstraintFailed),
-        [0] => Ok(bytes),
-        // [0, byte, ..] if *byte < 0x80 => Err(BerError::DerConstraintFailed),
-        // [0, rest @ ..] => Ok(&rest),
-        [0, rest @ ..] => remove_zeroes(rest),
-        // [byte, ..] if *byte >= 0x80 => Err(BerError::IntegerTooLarge),
-        _ => Ok(bytes),
-    }
-}
-
-// XXX const generics require rustc >= 1.51
-// /// Decode an unsigned integer into a byte array of the requested size
-// /// containing a big endian integer.
-// pub(crate) fn decode_array_uint<const N: usize>(bytes: &[u8]) -> Result<[u8; N], BerError> {
-//     // Check if MSB is set *before* leading zeroes
-//     if is_highest_bit_set(bytes) {
-//         return Err(BerError::IntegerNegative);
-//     }
-//     let input = remove_zeroes(bytes)?;
-
-//     if input.len() > N {
-//         return Err(BerError::IntegerTooLarge);
-//     }
-
-//     // Input has leading zeroes removed, so we need to add them back
-//     let mut output = [0u8; N];
-//     assert!(input.len() <= N);
-//     output[N.saturating_sub(input.len())..].copy_from_slice(input);
-//     Ok(output)
-// }
-
-pub(crate) fn decode_array_uint8(bytes: &[u8]) -> Result<[u8; 8], BerError> {
+pub(crate) fn decode_array_uint8(mut bytes: &[u8]) -> Result<u64, BerError> {
     // Check if MSB is set *before* leading zeroes
     if is_highest_bit_set(bytes) {
         return Err(BerError::IntegerNegative);
     }
-    let input = remove_zeroes(bytes)?;
 
-    if input.len() > 8 {
+    if bytes.len() > 9 {
         return Err(BerError::IntegerTooLarge);
+    } else if bytes.len() == 9 {
+        if bytes[0] != 0 {
+            return Err(BerError::IntegerTooLarge);
+        }
+        bytes = &bytes[1..];
     }
 
     // Input has leading zeroes removed, so we need to add them back
     let mut output = [0u8; 8];
-    assert!(input.len() <= 8);
-    output[8_usize.saturating_sub(input.len())..].copy_from_slice(input);
-    Ok(output)
+    output[8_usize.saturating_sub(bytes.len())..].copy_from_slice(bytes);
+    Ok(u64::from_be_bytes(output))
 }
 
-pub(crate) fn decode_array_uint4(bytes: &[u8]) -> Result<[u8; 4], BerError> {
+pub(crate) fn decode_array_uint4(mut bytes: &[u8]) -> Result<u32, BerError> {
     // Check if MSB is set *before* leading zeroes
     if is_highest_bit_set(bytes) {
         return Err(BerError::IntegerNegative);
     }
-    let input = remove_zeroes(bytes)?;
 
-    if input.len() > 4 {
+    if bytes.len() > 5 {
         return Err(BerError::IntegerTooLarge);
+    } else if bytes.len() == 5 {
+        if bytes[0] != 0 {
+            return Err(BerError::IntegerTooLarge);
+        }
+        bytes = &bytes[1..];
     }
 
     // Input has leading zeroes removed, so we need to add them back
     let mut output = [0u8; 4];
-    assert!(input.len() <= 4);
-    output[4_usize.saturating_sub(input.len())..].copy_from_slice(input);
-    Ok(output)
+    output[4_usize.saturating_sub(bytes.len())..].copy_from_slice(bytes);
+    Ok(u32::from_be_bytes(output))
 }
 
-// XXX const generics require rustc >= 1.51
-// /// Decode an unsigned integer of the specified size.
-// ///
-// /// Returns a byte array of the requested size containing a big endian integer.
-// pub(crate) fn decode_array_int<const N: usize>(input: &[u8]) -> Result<[u8; N], BerError> {
-//     let input = remove_zeroes(input)?;
-
-//     if input.len() > N {
-//         return Err(BerError::IntegerTooLarge);
-//     }
-
-//     // any.tag().assert_eq(Tag::Integer)?;
-//     let mut output = [0xFFu8; N];
-//     let offset = N.saturating_sub(input.len());
-//     output[offset..].copy_from_slice(input);
-//     Ok(output)
-// }
-
-pub(crate) fn decode_array_int8(input: &[u8]) -> Result<[u8; 8], BerError> {
-    let input = remove_zeroes(input)?;
-
-    if input.len() > 8 {
+pub(crate) fn decode_array_int8(input: &[u8]) -> Result<i64, BerError> {
+    let i_len = input.len();
+    if i_len > 8 {
         return Err(BerError::IntegerTooLarge);
     }
 
-    // any.tag().assert_eq(Tag::Integer)?;
-    let mut output = [0xFFu8; 8];
-    let offset = 8_usize.saturating_sub(input.len());
-    output[offset..].copy_from_slice(input);
-    Ok(output)
+    let mut output = [0x00u8; 8];
+    output[..i_len].copy_from_slice(input);
+
+    let result = i64::from_be_bytes(output);
+
+    Ok(result.wrapping_shr((8_u32 - (i_len as u32)) << 3))
 }
 
-pub(crate) fn decode_array_int4(input: &[u8]) -> Result<[u8; 4], BerError> {
-    let input = remove_zeroes(input)?;
-
-    if input.len() > 4 {
+pub(crate) fn decode_array_int4(input: &[u8]) -> Result<i32, BerError> {
+    let i_len = input.len();
+    if i_len > 4 {
         return Err(BerError::IntegerTooLarge);
     }
 
-    // any.tag().assert_eq(Tag::Integer)?;
-    let mut output = [0xFFu8; 4];
-    let offset = 4_usize.saturating_sub(input.len());
-    output[offset..].copy_from_slice(input);
-    Ok(output)
+    let mut output = [0x00u8; 4];
+    output[..i_len].copy_from_slice(input);
+
+    let result = i32::from_be_bytes(output);
+
+    Ok(result.wrapping_shr((4_u32 - (i_len as u32)) << 3))
 }
 
 /// Is the highest bit of the first byte in the slice 1? (if present)

--- a/tests/ber_parser.rs
+++ b/tests/ber_parser.rs
@@ -144,7 +144,6 @@ fn test_ber_int() {
 #[test_case(&hex!("02 02 01 23"), Ok(0x123) ; "u32-0x123")]
 #[test_case(&hex!("02 04 01 23 45 67"), Ok(0x0123_4567) ; "u32-long-ok")]
 #[test_case(&hex!("02 05 00 ff ff ff ff"), Ok(0xffff_ffff) ; "u32-long2-ok")]
-#[test_case(&hex!("02 06 00 00 01 23 45 67"), Ok(0x0123_4567) ; "u32-long-leading-zeros-ok")]
 #[test_case(&hex!("02 05 01 23 45 67 01"), Err(BerError::IntegerTooLarge) ; "u32 too large")]
 #[test_case(&hex!("02 09 01 23 45 67 01 23 45 67 ab"), Err(BerError::IntegerTooLarge) ; "u32 too large 2")]
 #[test_case(&hex!("03 03 01 00 01"), Err(BerError::unexpected_tag(Tag(2), Tag(3))) ; "invalid tag")]

--- a/tests/der_parser.rs
+++ b/tests/der_parser.rs
@@ -526,7 +526,7 @@ fn test_der_seq_dn_defined() {
 #[test_case(&hex!("02 02 00 ff"), Ok(255) ; "u32-255")]
 #[test_case(&hex!("02 02 01 23"), Ok(0x123) ; "u32-0x123")]
 #[test_case(&hex!("02 04 01 23 45 67"), Ok(0x0123_4567) ; "u32-long-ok")]
-#[test_case(&hex!("02 04 ff ff ff ff"), Err(BerError::IntegerNegative) ; "u32-long2-neg")]
+#[test_case(&hex!("02 04 f0 ff ff ff"), Err(BerError::IntegerNegative) ; "u32-long2-neg")]
 #[test_case(&hex!("02 06 00 00 01 23 45 67"), Err(BerError::DerConstraintFailed) ; "u32-long-leading-zeros")]
 #[test_case(&hex!("02 05 01 23 45 67 01"), Err(BerError::IntegerTooLarge) ; "u32 too large")]
 #[test_case(&hex!("02 09 01 23 45 67 01 23 45 67 ab"), Err(BerError::IntegerTooLarge) ; "u32 too large 2")]
@@ -548,6 +548,8 @@ fn tc_der_u32(i: &[u8], out: Result<u32, BerError>) {
 #[test_case(&hex!("02 01 80"), Ok(-128) ; "i32-neg128")]
 #[test_case(&hex!("02 02 ff 7f"), Ok(-129) ; "i32-neg129")]
 #[test_case(&hex!("02 02 00 ff"), Ok(255) ; "i32-255")]
+#[test_case(&hex!("02 06 ff 80 01 23 45 67"), Err(BerError::DerConstraintFailed) ; "i32-long-leading-ones")]
+#[test_case(&hex!("02 06 ff 70 01 23 45 67"), Err(BerError::IntegerTooLarge) ; "i32-too-large")]
 fn tc_der_i32(i: &[u8], out: Result<i32, BerError>) {
     let res = parse_der_i32(i);
     match out {


### PR DESCRIPTION
The current implementations of as_i64, as_i32, as_u64, and as_u32 are
all flawed (as well as the der validation of integers) when it comes to
handing particularities around negative integers. Of note is specifically
the following:

+ DER Validation doesn't properly enforce 8.3.2.b of x.690 for negative
  numbers. For example, 0xff 0xff should fail, but will not as the code
  currently only checks for whether the first 9 bytes are 0, not
  whether they are also 1.
+ as_i32 / as_i64 could incorrectly interpret a positive integer as a
  negative one. Ex: 0x00 0xff 0xff 0xff 0xff will be interpreted as -1
  instead of IntegerTooLarge (first bit is not set, so output will be filled
  with 0x00, 0x00 gets stripped off by remove_zeros, all bytes get
  overwritten by 0xff, thus an i64 taking in the buffer with
  from_be_bytes will be -1).
+ remove_zeros relies on TRO which is usually fine but suboptimial

This change will also make conversion more restrictive when 8.3.2
doesn't hold (even in BER cases) - if excess bytes are supplied, as_*
may report IntegerTooLarge even if the Integer could be represented as a
smaller integer (ex. 0x00 0x00 0x00 0x00 0x01 is accepted today for
as_u32 but will now return IntegerTooLarge). This wouldn't be a
regression in DER as such an encoding would (should?) fail validation,
only for BER.

This commit also makes other changes as well - there is generally less
branching, especially in the signed integer case (relying on shr for
extending the twos compliment bits).