### PR TITLE
loosen some lifetime restrictions

### DIFF
--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -241,13 +241,13 @@ impl<'a> BerObject<'a> {
 
     /// Attempt to get a reference on the content from an optional object.
     /// This can fail if the object is not optional.
-    pub fn as_optional(&'a self) -> Result<Option<&'_ BerObject<'a>>, BerError> {
+    pub fn as_optional(&self) -> Result<Option<&BerObject<'a>>, BerError> {
         self.content.as_optional()
     }
 
     /// Attempt to get a reference on the content from a tagged object.
     /// This can fail if the object is not tagged.
-    pub fn as_tagged(&'a self) -> Result<(Class, Tag, &'_ BerObject<'a>), BerError> {
+    pub fn as_tagged(&self) -> Result<(Class, Tag, &BerObject<'a>), BerError> {
         self.content.as_tagged()
     }
 
@@ -262,7 +262,7 @@ impl<'a> BerObject<'a> {
 
     /// Attempt to read a BitString value from DER object.
     /// This can fail if the object is not an BitString.
-    pub fn as_bitstring(&'a self) -> Result<BitStringObject<'a>, BerError> {
+    pub fn as_bitstring(&self) -> Result<BitStringObject<'a>, BerError> {
         self.content.as_bitstring()
     }
 
@@ -533,7 +533,7 @@ impl<'a> BerObjectContent<'a> {
         self.as_oid().map(|o| o.clone())
     }
 
-    pub fn as_optional(&'a self) -> Result<Option<&'_ BerObject<'a>>, BerError> {
+    pub fn as_optional(&self) -> Result<Option<&BerObject<'a>>, BerError> {
         match *self {
             BerObjectContent::Optional(Some(ref o)) => Ok(Some(o)),
             BerObjectContent::Optional(None) => Ok(None),
@@ -541,7 +541,7 @@ impl<'a> BerObjectContent<'a> {
         }
     }
 
-    pub fn as_tagged(&'a self) -> Result<(Class, Tag, &'_ BerObject<'a>), BerError> {
+    pub fn as_tagged(&self) -> Result<(Class, Tag, &BerObject<'a>), BerError> {
         match *self {
             BerObjectContent::Tagged(class, tag, ref o) => Ok((class, tag, o.as_ref())),
             _ => Err(BerError::BerTypeError),
@@ -555,7 +555,7 @@ impl<'a> BerObjectContent<'a> {
         }
     }
 
-    pub fn as_bitstring(&'a self) -> Result<BitStringObject<'a>, BerError> {
+    pub fn as_bitstring(&self) -> Result<BitStringObject<'a>, BerError> {
         match *self {
             BerObjectContent::BitString(_, ref b) => Ok(b.to_owned()),
             _ => Err(BerError::BerTypeError),


### PR DESCRIPTION
I think annotating these `self` references is overly restrictive. Suppose I am parsing a `&'static [u8]` and call (e.g.) `as_tagged` within a function. Then `'a` will get narrowed to the lifetime of the current function. This makes it impossible to return anything borrowed from the return of `as_tagged` from the function.

More concretely, the following compiles after merging this PR...

```rust
fn foo(i: &'static [u8]) -> der_parser::error::BerResult<&'static [u8]> {
    let (rem, obj) = der_parser::parse_ber(i)?;
    Ok((rem, obj.as_tagged()?.2.as_slice()?))
}
```

...but fails to compile under `master`...

```
error[E0515]: cannot return value referencing local variable `obj`
   --> src/foo.rs:3:5
    |
    |     Ok((rem, obj.as_tagged()?.2.as_slice()?))
    |     ^^^^^^^^^---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     |        |
    |     |        `obj` is borrowed here
    |     returns a value referencing data owned by the current function
```