### PR TITLE
ci: fix clippy findings, update cargo-check-external-types toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install cargo-check-external-types
       - run: cargo check-external-types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ num-bigint = { version = "0.4", optional = true }
 
 [features]
 default = ["std"]
+bitvec = []
 bigint = ["num-bigint"]
 serialize = ["std", "cookie-factory"]
 unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@
     missing_debug_implementations,
 )]
 // pragmas for doc
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(test(
     no_crate_inject,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,11 @@
 //!
 //! The second (and preferred) parsing method is to specify the expected objects recursively. The
 //! following functions can be used:
+//!
 //! - [`parse_ber_sequence_defined`](ber/fn.parse_ber_sequence_defined.html) and similar functions
+//!
 //! for sequences and sets variants
+//!
 //! - [`parse_ber_tagged_explicit`](ber/fn.parse_ber_tagged_explicit.html) for tagged explicit
 //! - [`parse_ber_tagged_implicit`](ber/fn.parse_ber_tagged_implicit.html) for tagged implicit
 //! - [`parse_ber_container`](ber/fn.parse_ber_container.html) for generic parsing, etc.


### PR DESCRIPTION
👋 As promised, when cargo-check-external-types makes an update I'm opening PRs to fix the builds :-) This project also had several clippy findings that are fixed along the way.

See commit messages for individual explanations. I _think_ adding a `bitvec` feature is the correct fix for the `unexpected_cfgs` finding, but this should be double checked.