### PR TITLE
Fix invalid handling of UTF-16 strings

### DIFF
--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -70,8 +70,11 @@ pub enum BerObjectContent<'a> {
     /// VideotexString: decoded string
     VideotexString(&'a str),
 
-    /// BmpString: decoded string
-    BmpString(&'a str),
+    /// BmpString: raw object bytes
+    ///
+    /// Note: the string is stored as raw bytes because not all UTF-16 sequences can be stored as
+    /// `&str`. To access content, use `String::from_utf16` or `String::from_utf16_lossy`.
+    BmpString(&'a [u8]),
     /// UniversalString: raw object bytes
     UniversalString(&'a [u8]),
 
@@ -589,7 +592,6 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_slice(&self) -> Result<&'a [u8],BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
-            BerObjectContent::BmpString(s) |
             BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::GeneralString(s) |
@@ -602,6 +604,7 @@ impl<'a> BerObjectContent<'a> {
             BerObjectContent::Integer(s) |
             BerObjectContent::BitString(_,BitStringObject{data:s}) |
             BerObjectContent::OctetString(s) |
+            BerObjectContent::BmpString(s) |
             BerObjectContent::UniversalString(s) => Ok(s),
             BerObjectContent::Unknown(ref any) => Ok(any.data),
             _ => Err(BerError::BerTypeError),
@@ -612,7 +615,6 @@ impl<'a> BerObjectContent<'a> {
     pub fn as_str(&self) -> Result<&'a str,BerError> {
         match *self {
             BerObjectContent::NumericString(s) |
-            BerObjectContent::BmpString(s) |
             BerObjectContent::VisibleString(s) |
             BerObjectContent::PrintableString(s) |
             BerObjectContent::GeneralString(s) |

--- a/src/ber/print.rs
+++ b/src/ber/print.rs
@@ -109,6 +109,18 @@ impl fmt::Debug for PrettyBer<'_> {
             dbg_header(&self.obj.header, f)?;
             write!(f, " ")?;
         };
+        fn print_utf16_string_with_type(f: &mut fmt::Formatter, s: &[u8], ty: &str) -> fmt::Result {
+            let v: Vec<_> = s
+                .chunks_exact(2)
+                .map(|a| u16::from_be_bytes([a[0], a[1]]))
+                .collect();
+            let s = String::from_utf16(&v);
+
+            match s {
+                Ok(s)  => writeln!(f, "{}(\"{}\")", ty, s),
+                Err(_) => writeln!(f, "{}({:?}) <error decoding utf32 string>", ty, s),
+            }
+        }
         fn print_utf32_string_with_type(f: &mut fmt::Formatter, s: &[u8], ty: &str) -> fmt::Result {
             let chars: Option<Vec<char>> = s
                 .chunks_exact(4)
@@ -143,7 +155,7 @@ impl fmt::Debug for PrettyBer<'_> {
             BerObjectContent::T61String(s)           => write!(f, "T61String({})", s),
             BerObjectContent::VideotexString(s)      => write!(f, "VideotexString({})", s),
             BerObjectContent::ObjectDescriptor(s)    => write!(f, "ObjectDescriptor(\"{}\")", s),
-            BerObjectContent::BmpString(s)           => write!(f, "BmpString(\"{}\")", s),
+            BerObjectContent::BmpString(s)           => print_utf16_string_with_type(f, s, "BmpString"),
             BerObjectContent::UniversalString(s)     => print_utf32_string_with_type(f, s, "UniversalString"),
             BerObjectContent::Optional(ref o) => {
                 match o {

--- a/src/ber/serialize.rs
+++ b/src/ber/serialize.rs
@@ -142,7 +142,6 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
             ber_encode_datetime(time)(out)
         }
         BerObjectContent::NumericString(s)
-        | BerObjectContent::BmpString(s)
         | BerObjectContent::GeneralString(s)
         | BerObjectContent::ObjectDescriptor(s)
         | BerObjectContent::GraphicString(s)
@@ -152,6 +151,7 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
         | BerObjectContent::T61String(s)
         | BerObjectContent::VideotexString(s)
         | BerObjectContent::UTF8String(s) => slice(s)(out),
+        BerObjectContent::BmpString(s) => slice(s)(out),
         BerObjectContent::UniversalString(s) => slice(s)(out),
         BerObjectContent::Sequence(v) | BerObjectContent::Set(v) => ber_encode_sequence(v)(out),
         // best we can do is tagged-explicit, but we don't know

--- a/src/ber/visit.rs
+++ b/src/ber/visit.rs
@@ -24,7 +24,7 @@ pub trait Visit<'a> {
     fn visit_ber_bitstring(&mut self, ignored: u8, data: &'a BitStringObject, depth: usize) {}
 
     /// Called for BER bmpstring objects
-    fn visit_ber_bmpstring(&mut self, s: &'a str, depth: usize) {}
+    fn visit_ber_bmpstring(&mut self, s: &'a [u8], depth: usize) {}
 
     /// Called for BER boolean objects
     fn visit_ber_boolean(&mut self, b: bool, depth: usize) {}

--- a/src/ber/visit_mut.rs
+++ b/src/ber/visit_mut.rs
@@ -31,7 +31,7 @@ pub trait VisitMut<'a> {
     }
 
     /// Called for BER bmpstring objects
-    fn visit_ber_bmpstring_mut(&mut self, s: &'a mut &'_ str, depth: usize) {}
+    fn visit_ber_bmpstring_mut(&mut self, s: &'a mut &'_ [u8], depth: usize) {}
 
     /// Called for BER boolean objects
     fn visit_ber_boolean_mut(&mut self, b: &'a mut bool, depth: usize) {}

--- a/src/ber/wrap_any.rs
+++ b/src/ber/wrap_any.rs
@@ -1,4 +1,4 @@
-use std::string::String;
+use alloc::string::String;
 
 use super::{BerObject, BerObjectContent, BitStringObject};
 use crate::ber::{ber_get_object_content, MAX_OBJECT_SIZE};

--- a/src/ber/wrap_any.rs
+++ b/src/ber/wrap_any.rs
@@ -107,7 +107,7 @@ fn try_berobject_from_any(any: Any, max_depth: usize) -> Result<BerObject> {
                 .map(|a| u16::from_be_bytes([a[0], a[1]]))
                 .collect();
             let _s = String::from_utf16(&v)?;
-            Ok(obj_from(header, BerObjectContent::BmpString(&any.data)))
+            Ok(obj_from(header, BerObjectContent::BmpString(any.data)))
         }
         Tag::Boolean => {
             let b = any.bool()?;

--- a/tests/ber_parser.rs
+++ b/tests/ber_parser.rs
@@ -472,7 +472,7 @@ fn test_ber_relativeoid() {
 fn test_ber_bmpstring() {
     let empty = &b""[..];
     let bytes = hex!("1e 08 00 55 00 73 00 65 00 72");
-    let expected = BerObject::from_obj(BerObjectContent::BmpString("\x00U\x00s\x00e\x00r"));
+    let expected = BerObject::from_obj(BerObjectContent::BmpString(b"\x00U\x00s\x00e\x00r"));
     assert_eq!(parse_ber_bmpstring(&bytes), Ok((empty, expected)));
 }
 


### PR DESCRIPTION
Fix storage of UTF-16 strings:
- we can't use a `&str` as currently, because `&str` is UTF-8 and cannot represent all UTF-16 characters, and also because reading the UTF-16 string (as big-endian) requires an allocation to convert (returning a `String`, not a `&str`)
- store as a slice (but validate charset) to avoid allocations