### PR TITLE
Fix ENUMERATED serialization to produce valid ASN.1 encoding

### DIFF
--- a/src/ber/serialize.rs
+++ b/src/ber/serialize.rs
@@ -129,12 +129,15 @@ fn ber_encode_object_content<'a, W: Write + Default + AsRef<[u8]> + 'a>(
         BerObjectContent::OctetString(s) => slice(s)(out),
         BerObjectContent::Null => Ok(out),
         BerObjectContent::Enum(i) => {
-            let v: Vec<u8> = i
-                .to_be_bytes()
-                .iter()
-                .cloned()
-                .skip_while(|&b| b == 0)
-                .collect();
+            let bytes = i.to_be_bytes();
+            // Find first non-zero byte, but always keep at least one byte (for value 0)
+            let start = bytes.iter().position(|&b| b != 0).unwrap_or(7);
+            // Add leading 0x00 if MSB is set (to indicate positive value in two's complement)
+            let v = if bytes[start] >= 0x80 {
+                [&[0x00], &bytes[start..]].concat()
+            } else {
+                bytes[start..].to_vec()
+            };
             slice(v)(out)
         }
         BerObjectContent::OID(oid) | BerObjectContent::RelativeOID(oid) => ber_encode_oid(oid)(out),

--- a/tests/primitive.rs
+++ b/tests/primitive.rs
@@ -232,3 +232,35 @@ fn test_print_unexpected() {
 
     eprintln!("{}", BerError::BerMaxDepth);
 }
+
+#[cfg(feature = "serialize")]
+#[test]
+fn test_enum_serialization_minimal_encoding() {
+    // Test that ENUMERATED values are always encoded with at least one octet
+    // and use minimal encoding with proper sign handling
+
+    // Enum(0) should encode as [0x0a, 0x01, 0x00]
+    let obj = BerObject::from_obj(BerObjectContent::Enum(0));
+    let serialized = obj.to_vec().expect("serialization failed");
+    assert_eq!(serialized, vec![0x0a, 0x01, 0x00], "Enum(0) must have one content octet");
+
+    // Enum(127) should encode as [0x0a, 0x01, 0x7f] (positive, no leading zero needed)
+    let obj = BerObject::from_obj(BerObjectContent::Enum(127));
+    let serialized = obj.to_vec().expect("serialization failed");
+    assert_eq!(serialized, vec![0x0a, 0x01, 0x7f], "Enum(127) encodes as single byte");
+
+    // Enum(128) should encode as [0x0a, 0x02, 0x00, 0x80] (needs leading zero to indicate positive)
+    let obj = BerObject::from_obj(BerObjectContent::Enum(128));
+    let serialized = obj.to_vec().expect("serialization failed");
+    assert_eq!(serialized, vec![0x0a, 0x02, 0x00, 0x80], "Enum(128) needs leading zero for positive indication");
+
+    // Enum(255) should encode as [0x0a, 0x02, 0x00, 0xff]
+    let obj = BerObject::from_obj(BerObjectContent::Enum(255));
+    let serialized = obj.to_vec().expect("serialization failed");
+    assert_eq!(serialized, vec![0x0a, 0x02, 0x00, 0xff], "Enum(255) needs leading zero");
+
+    // Enum(256) should encode as [0x0a, 0x02, 0x01, 0x00]
+    let obj = BerObject::from_obj(BerObjectContent::Enum(256));
+    let serialized = obj.to_vec().expect("serialization failed");
+    assert_eq!(serialized, vec![0x0a, 0x02, 0x01, 0x00], "Enum(256) minimal encoding");
+}


### PR DESCRIPTION
## Summary

This PR fixes serialization of ENUMERATED values to ensure compliance with ASN.1 encoding rules (X.690).

## Problem

The current implementation has two issues when serializing ENUMERATED values:

1. **Empty content for zero**: `Enum(0)` serializes as `[0x0a, 0x00]` (tag + zero length), violating X.690 §8.4 which requires at least 1 content octet
2. **Sign ambiguity**: Values ≥128 like `Enum(128)` serialize as `[0x0a, 0x01, 0x80]` which represents -128 in two's complement, not +128

## Solution

Modified `src/ber/serialize.rs` to:
- Always preserve at least 1 content octet (never produce empty content)
- Add leading 0x00 byte when MSB is set on positive values to prevent sign ambiguity

## Testing

Added comprehensive test `test_enum_serialization_minimal_encoding` in `tests/primitive.rs` covering:
- Enum(0) → valid 1-byte content
- Enum(127) → single byte (no padding needed)
- Enum(128) → two bytes with leading 0x00
- Enum(255) → two bytes with leading 0x00
- Enum(256) → two bytes, no padding needed

All tests pass and follow existing test patterns in the codebase.

## Impact

This fix ensures:
- Round-trip serialization/deserialization works correctly
- Generated encodings are valid per ASN.1 standards
- No breaking changes to parsing (only serialization behavior)