### PR TITLE
Add overflow detection to as_i64() and as_i32() methods

### DIFF
--- a/src/ber/ber.rs
+++ b/src/ber/ber.rs
@@ -414,7 +414,11 @@ impl<'a> BerObjectContent<'a> {
             let result = if is_highest_bit_set(bytes) {
                 <i64>::from_be_bytes(decode_array_int8(bytes)?)
             } else {
-                <u64>::from_be_bytes(decode_array_uint8(bytes)?) as i64
+                let unsigned_val = <u64>::from_be_bytes(decode_array_uint8(bytes)?);
+                if unsigned_val > i64::MAX as u64 {
+                    return Err(BerError::IntegerTooLarge);
+                }
+                unsigned_val as i64
             };
             Ok(result)
         } else {
@@ -441,7 +445,11 @@ impl<'a> BerObjectContent<'a> {
             let result = if is_highest_bit_set(bytes) {
                 <i32>::from_be_bytes(decode_array_int4(bytes)?)
             } else {
-                <u32>::from_be_bytes(decode_array_uint4(bytes)?) as i32
+                let unsigned_val = <u32>::from_be_bytes(decode_array_uint4(bytes)?);
+                if unsigned_val > i32::MAX as u32 {
+                    return Err(BerError::IntegerTooLarge);
+                }
+                unsigned_val as i32
             };
             Ok(result)
         } else {

--- a/tests/ber_parser.rs
+++ b/tests/ber_parser.rs
@@ -202,6 +202,40 @@ fn tc_ber_i64(i: &[u8], out: Result<i64, BerError>) {
     }
 }
 
+#[test]
+fn test_as_i64_overflow_detection() {
+    use der_parser::ber::*;
+
+    // Valid positive value within i64::MAX
+    let obj = BerObject::from_int_slice(b"\x7f\xff\xff\xff\xff\xff\xff\xff"); // i64::MAX
+    assert_eq!(obj.as_i64(), Ok(i64::MAX));
+
+    // Positive value exceeding i64::MAX should return error
+    let obj = BerObject::from_int_slice(b"\x00\x80\x00\x00\x00\x00\x00\x00\x00"); // i64::MAX + 1
+    assert_eq!(obj.as_i64(), Err(BerError::IntegerTooLarge));
+
+    // Negative values should still work
+    let obj = BerObject::from_int_slice(b"\x80\x00\x00\x00\x00\x00\x00\x00"); // i64::MIN
+    assert_eq!(obj.as_i64(), Ok(i64::MIN));
+}
+
+#[test]
+fn test_as_i32_overflow_detection() {
+    use der_parser::ber::*;
+
+    // Valid positive value within i32::MAX
+    let obj = BerObject::from_int_slice(b"\x7f\xff\xff\xff"); // i32::MAX
+    assert_eq!(obj.as_i32(), Ok(i32::MAX));
+
+    // Positive value exceeding i32::MAX should return error
+    let obj = BerObject::from_int_slice(b"\x00\x80\x00\x00\x00"); // i32::MAX + 1
+    assert_eq!(obj.as_i32(), Err(BerError::IntegerTooLarge));
+
+    // Negative values should still work
+    let obj = BerObject::from_int_slice(b"\x80\x00\x00\x00"); // i32::MIN
+    assert_eq!(obj.as_i32(), Ok(i32::MIN));
+}
+
 #[cfg(feature = "bigint")]
 #[test_case(&hex!("02 01 01"), Ok(BigInt::from(1)) ; "bigint-1")]
 #[test_case(&hex!("02 02 00 ff"), Ok(BigInt::from(255)) ; "bigint-255")]


### PR DESCRIPTION
## Summary

This PR adds overflow detection to the `as_i64()` and `as_i32()` methods to prevent silent data corruption when converting large positive integers.

## Problem

The current implementation performs unchecked casting from unsigned to signed types:

```rust
<u64>::from_be_bytes(decode_array_uint8(bytes)?) as i64
```

When a positive integer exceeds `i64::MAX` (9223372036854775807), the cast silently wraps to negative values through two's complement overflow. For example, `2^63` wraps to `i64::MIN` (-9223372036854775808).

This violates the principle of least surprise and can lead to subtle bugs where invalid values appear to parse successfully.

## Solution

Added explicit overflow checks before casting:

```rust
let unsigned_val = <u64>::from_be_bytes(decode_array_uint8(bytes)?);
if unsigned_val > i64::MAX as u64 {
    return Err(BerError::IntegerTooLarge);
}
unsigned_val as i64
```

Applied the same fix to both `as_i64()` and `as_i32()` methods in `src/ber/ber.rs`.

## Testing

Added two new tests in `tests/ber_parser.rs`:

1. `test_as_i64_overflow_detection` - Verifies:
   - Values within range work correctly (i64::MAX)
   - Values exceeding range return `IntegerTooLarge` error
   - Negative values still work (i64::MIN)

2. `test_as_i32_overflow_detection` - Same coverage for i32

All existing tests continue to pass.

## Impact

- **API behavior**: Methods now return errors for unrepresentable values instead of wrapping
- **Backwards compatibility**: Code that previously succeeded with wrapped values will now receive explicit errors, which is a safer failure mode
- **No impact on parsing**: Only affects the conversion helper methods