### PR TITLE
Add DER canonicality check for negative integers

### DIFF
--- a/src/der/parser.rs
+++ b/src/der/parser.rs
@@ -518,6 +518,11 @@ pub fn der_read_element_content_as(
                         DerConstraint::IntegerLeadingZeroes,
                     )));
                 }
+                [0xff, byte, ..] if byte >= 0x80 => {
+                    return Err(Err::Error(BerError::DerConstraintFailed(
+                        DerConstraint::IntegerLeadingZeroes,
+                    )));
+                }
                 _ => (),
             }
         }

--- a/tests/der_parser.rs
+++ b/tests/der_parser.rs
@@ -57,6 +57,41 @@ fn test_der_int() {
 }
 
 #[test]
+fn test_der_integer_canonicality() {
+    use der_parser::der::parse_der_integer;
+    use der_parser::error::DerConstraint;
+
+    // Canonical positive integers should pass
+    assert!(parse_der_integer(&hex!("02 01 7f")).is_ok());  // 127
+    assert!(parse_der_integer(&hex!("02 02 00 80")).is_ok());  // 128 (needs leading 0)
+
+    // Canonical negative integers should pass
+    assert!(parse_der_integer(&hex!("02 01 80")).is_ok());  // -128
+    assert!(parse_der_integer(&hex!("02 02 ff 7f")).is_ok());  // -129
+
+    // Non-canonical positive integer: redundant leading zeros
+    let result = parse_der_integer(&hex!("02 02 00 7f"));  // Should be [02 01 7f]
+    assert!(matches!(
+        result,
+        Err(nom::Err::Error(BerError::DerConstraintFailed(DerConstraint::IntegerLeadingZeroes)))
+    ));
+
+    // Non-canonical negative integer: redundant leading 0xFF bytes
+    let result = parse_der_integer(&hex!("02 02 ff 80"));  // Should be [02 01 80]
+    assert!(matches!(
+        result,
+        Err(nom::Err::Error(BerError::DerConstraintFailed(DerConstraint::IntegerLeadingZeroes)))
+    ));
+
+    // Another non-canonical negative: value -1 with redundant 0xFF
+    let result = parse_der_integer(&hex!("02 02 ff ff"));  // Should be [02 01 ff]
+    assert!(matches!(
+        result,
+        Err(nom::Err::Error(BerError::DerConstraintFailed(DerConstraint::IntegerLeadingZeroes)))
+    ));
+}
+
+#[test]
 fn test_der_bitstring_primitive() {
     let empty = &b""[..];
     //


### PR DESCRIPTION
## Summary

This PR adds a missing DER constraint check for negative integer encodings to ensure canonical representation as required by X.690 Distinguished Encoding Rules.

## Problem

DER (Distinguished Encoding Rules) requires that each value has exactly **one** valid encoding. The current implementation checks for redundant leading zeros in positive integers but does not check for redundant leading `0xFF` bytes in negative integers.

This allows multiple encodings of the same negative value:
- `-128` can be encoded as `[0x02, 0x01, 0x80]` (canonical) or `[0x02, 0x02, 0xff, 0x80]` (non-canonical)
- `-129` can be encoded as `[0x02, 0x02, 0xff, 0x7f]` (canonical) or `[0x02, 0x03, 0xff, 0xff, 0x7f]` (non-canonical)

This violates DER's uniqueness guarantee, which is critical for applications like cryptographic signatures where byte-for-byte equality is required.

## Solution

Added validation in `src/der/parser.rs` at the existing integer constraint check location:

```rust
[0xff, byte, ..] if byte >= 0x80 => {
    return Err(Err::Error(BerError::DerConstraintFailed(
        DerConstraint::IntegerLeadingZeroes,
    )));
}
```

When a negative integer (in two's complement) starts with `0xff` followed by a byte with MSB set, the leading `0xff` is redundant and should be removed for canonical encoding.

## Testing

Added comprehensive test `test_der_integer_canonicality` in `tests/der_parser.rs` covering:

**Canonical encodings (should pass):**
- Positive: 127, 128 (with necessary leading 0)
- Negative: -128, -129

**Non-canonical encodings (should be rejected):**
- Positive with redundant leading zeros
- Negative with redundant leading 0xFF bytes

## Impact

- **Stricter DER validation**: Non-canonical negative integers are now properly rejected
- **Standards compliance**: Aligns with X.690 DER requirements
- **No impact on valid data**: Canonical encodings continue to work as before
- **BER mode unchanged**: Only affects DER parsing (BER allows non-canonical encodings)